### PR TITLE
refactor: importable module and event struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ There is a [client implementation in Rust](https://github.com/trudi-group/ipfs-t
 Events sent by this plugin are of this format:
 ```go
 // The type sent to via TCP for pushed events.
-type event struct {
+type Event struct {
 	// The timestamp at which the event was recorded.
 	// This defines an ordering for events.
 	Timestamp time.Time `json:"timestamp"`

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module meplugin
+module github.com/trudi-group/ipfs-metric-exporter
 
 go 1.19
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	pl "meplugin/metricplugin"
+	pl "github.com/trudi-group/ipfs-metric-exporter/metricplugin"
 
 	"github.com/ipfs/kubo/plugin"
 )

--- a/metricplugin/api.go
+++ b/metricplugin/api.go
@@ -5,7 +5,7 @@ import (
 
 	bsmsg "github.com/ipfs/go-bitswap/message"
 	pbmsg "github.com/ipfs/go-bitswap/message/pb"
-	"github.com/ipfs/go-cid"
+	cid "github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	ma "github.com/multiformats/go-multiaddr"

--- a/metricplugin/bitswap_discovery_probe.go
+++ b/metricplugin/bitswap_discovery_probe.go
@@ -9,7 +9,7 @@ import (
 	bsmsg "github.com/ipfs/go-bitswap/message"
 	pbmsg "github.com/ipfs/go-bitswap/message/pb"
 	bsnet "github.com/ipfs/go-bitswap/network"
-	"github.com/ipfs/go-cid"
+	cid "github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"

--- a/metricplugin/metric_export.go
+++ b/metricplugin/metric_export.go
@@ -14,7 +14,7 @@ import (
 
 	bs "github.com/ipfs/go-bitswap"
 	bsnet "github.com/ipfs/go-bitswap/network"
-	"github.com/ipfs/go-cid"
+	cid "github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log"
 	"github.com/ipfs/kubo/core"
 	"github.com/ipfs/kubo/plugin"


### PR DESCRIPTION
- Renamed module so that external projects can `go get github.com/trudi-group/ipfs-metric-exporter`
- Made `type event struct` public 